### PR TITLE
Bump version and development status from pre-alpha to beta.

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -1,9 +1,5 @@
 name: Docker Images to DockerHub
 on:
-  pull_request:
-  push:
-    branches:
-      - master
   release:
     types:
       - published

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches:
       - master
-
+  release:
+    types:
+      - published
   workflow_dispatch:
 
 jobs:

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     author="Wise::Observability",
     author_email="observability@transferwise.com",
     classifiers=[
-        "Development Status :: 2 - Pre-Alpha",
+        "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
         "Natural Language :: English",
@@ -50,6 +50,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/transferwise/cloudflare-exporter",
-    version="0.4.0",
+    version="0.4.1",
     zip_safe=False,
 )


### PR DESCRIPTION
## Context

<!-- Why is this PR necessary? If available, include links to a JIRA ticket or other relevant documentation. -->
Tried re-running previous failed docker hub upload, but got an error because the tag couldn't be generated from the PR.

<img width="576" alt="Screenshot 2025-03-20 at 15 50 26" src="https://github.com/user-attachments/assets/41b2c747-7337-48ea-9441-75cdcfdfa28b" />

Chnage release workflow in a way we could publish images to Docker hub.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
