### PR TITLE
CAMPAIGN-54: migrate to tw-base-python base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,17 @@
-FROM python:3.12-slim
+FROM tw-base-python.arti.tw.ee/tw-base-python:3.12
 LABEL "MAINTAINER"="Wise"
 
 COPY ./ /app
 WORKDIR /app
 
+# tw-base-python runs as non-root (UID 65534). pip install writes into
+# system site-packages, which requires root, so switch to root for the install.
+USER 0
 RUN pip install .
+RUN chown -R 65534 /app
 
 EXPOSE 5000
 
+# Drop back to the non-root user before running the entrypoint.
+USER 65534
 ENTRYPOINT ["cfexpose", "export"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,7 @@ WORKDIR /app
 # tw-base-python runs as non-root (UID 65534). pip install writes into
 # system site-packages, which requires root, so switch to root for the install.
 USER 0
-RUN pip install .
-RUN chown -R 65534 /app
+RUN pip install . && chown -R 65534:65534 /app
 
 EXPOSE 5000
 


### PR DESCRIPTION
## Context

Part of [CAMPAIGN-54](https://transferwise.atlassian.net/browse/CAMPAIGNS-54). All Python services must use the standard `tw-base-python` base image so the platform can apply consistent security patching, the `com.transferwise.language` label, and SLSA tooling uniformly. Please review and make sure the changes are safe.

This service was on the official `python:3.12-slim` image. This PR migrates it to `tw-base-python:3.12`.

## Changes

- Swapped `FROM python:3.12-slim` for `FROM tw-base-python.arti.tw.ee/tw-base-python:3.12` (same Python version).
- `tw-base-python` runs as the non-root user UID 65534 (unlike `python:slim` which runs as root), so `pip install .` (which writes into system site-packages) is wrapped with `USER 0`.
- Added `chown -R 65534 /app` so the runtime user can read the app directory.
- Added `USER 65534` before the `ENTRYPOINT` so the container runs as non-root.

## Test plan

- [ ] `docker build` succeeds against `tw-base-python.arti.tw.ee/tw-base-python:3.12`.
- [ ] Container starts and `cfexpose export` runs as UID 65534.
- [ ] `/metrics` on port 5000 responds as before.